### PR TITLE
add PhantomFn marker trait for Pair.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub trait ActOn<T>: Pair {
 }
 
 /// Used to reduce the need for associated types.
-pub trait Pair {
+pub trait Pair: std::marker::PhantomFn<Self> {
     type Data;
     type Object;
 }


### PR DESCRIPTION
This is a simple fix; the latest rust `522d09dfe 2015-02-19` requires a `PhantomFn` trait for traits that do not use Self.

The error is `error: parameter`Self`is never used`.
